### PR TITLE
Fix punctuation bug

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+17
+version: 1.0.0+18
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"


### PR DESCRIPTION
_prepToken for some reason was using two different variables
(I'm not sure why I did that) - but it meant that some of the fixups
didn't apply.

After that, apply all the fixups before searching the stopword list.